### PR TITLE
Use HTTPS in project.clj :url

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject cljr-nsca "0.0.3"
   :description "Clojure wrapper for jsendnsca - Send passive Nagios checks from Clojure."
-  :url "http://github.com/mcorbin/clj-nsca"
+  :url "https://github.com/mcorbin/clj-nsca"
   :repositories {"redhat" "https://maven.repository.redhat.com/ga/"}
   :dependencies [[com.googlecode/jsendnsca-core "1.3.1"]]
   :license {:name "Eclipse Public License - v 1.0"


### PR DESCRIPTION
Getting a TLS error on some platforms that prevent retrieving dependencies without hacky workarounds. This should fix the issue.

If/when this is deployed to 0.0.4 I would suggest bumping the dependency in the Riemann project file to 0.0.4 as well.

Cheers!